### PR TITLE
comment notebook service in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,12 @@ services:
       - 53773
     volumes:
       - ./:/irisdev/app
-  notebook:
-    build: 
-      context: notebook
-      dockerfile: dockerfile
-    ports:
-      - "8888:8888"
-    volumes:
-      - ./notebook/Notebooks:/Notebooks
-    command: "start-notebook.sh --NotebookApp.token='' --NotebookApp.password='' --notebook-dir=/Notebooks"
+  # notebook:
+  #   build: 
+  #     context: notebook
+  #     dockerfile: dockerfile
+  #   ports:
+  #     - "8888:8888"
+  #   volumes:
+  #     - ./notebook/Notebooks:/Notebooks
+  #   command: "start-notebook.sh --NotebookApp.token='' --NotebookApp.password='' --notebook-dir=/Notebooks"


### PR DESCRIPTION
Due to dependencies errors during the build phase, the option was taken to remove the notebook (not used in the demo)